### PR TITLE
imx6: images: ventana: change name of ubi output

### DIFF
--- a/target/linux/imx6/image/Makefile
+++ b/target/linux/imx6/image/Makefile
@@ -102,9 +102,10 @@ define Device/ventana
 		imx6q-gw5400-a \
 		imx6q-gw551x \
 		imx6q-gw552x
-	IMAGES := nand-factory_normal.ubi nand-factory_large.ubi
-	IMAGE/nand-factory_normal.ubi := ubi-boot-overlay normal 2048 124KiB 128KiB 8124
-	IMAGE/nand-factory_large.ubi := ubi-boot-overlay large 4096 248KiB 256KiB 8124
+	IMAGES := nand_normal.ubi nand_large.ubi
+	IMAGE/nand_normal.ubi := ubi-boot-overlay normal 2048 124KiB 128KiB 8124
+	IMAGE/nand_large.ubi := ubi-boot-overlay large 4096 248KiB 256KiB 8124
+	IMAGE_NAME = $$(IMAGE_PREFIX)-$$(1)-$$(2)
 endef
 
 define Device/wandboard


### PR DESCRIPTION
Change the name of the .ubi produced to strip out the word 'factory'. This is
mainly due to the fact that there is no difference between the Ventana 'factory'
image vs the standard image.

Name changes from:
openwrt-imx6-ventana-squashfs.nand-factory_<size>.ubi to
openwrt-imx6-ventana-squashfs-nand_<size>.ubi

Signed-off-by: Pushpal Sidhu <psidhu@gateworks.com>

git-svn-id: svn://svn.openwrt.org/openwrt/trunk@48016 3c298f89-4303-0410-b956-a3cf2f4a3e73