### PR TITLE
dante: fix MD5SUM

### DIFF
--- a/package/network/utils/dante/Makefile
+++ b/package/network/utils/dante/Makefile
@@ -13,7 +13,7 @@ PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
 PKG_SOURCE_URL:=http://www.inet.no/dante/files/
-PKG_MD5SUM:=69b9d6234154d7d6a91fcbd98c68e62a
+PKG_MD5SUM:=68c2ce12119e12cea11a90c7a80efa8f
 
 PKG_MAINTAINER:=Jo-Philipp Wich <jow@openwrt.org>
 PKG_LICENSE:=BSD-4-Clause


### PR DESCRIPTION
MD5SUM is wrong, it was not updated during last update to v1.4.1.

Thanks to Daniel Dickinson <openwrt@daniel.thecshore.com> for reporting it.

Signed-off-by: Nicolas Thill <nico@openwrt.org>

git-svn-id: svn://svn.openwrt.org/openwrt/trunk@48017 3c298f89-4303-0410-b956-a3cf2f4a3e73